### PR TITLE
Fix DeteKt issues

### DIFF
--- a/deep-clean.kts
+++ b/deep-clean.kts
@@ -168,9 +168,10 @@ fun File.removeFilesWithExtension(extension: String) {
             !it.isDirectory && it.extension.equals(extension, ignoreCase = true)
         }
 
-    when {
-        backup -> matchingFiles.backupAndDeleteByRenaming()
-        else -> matchingFiles.deleteRecursively()
+    if (backup) {
+        matchingFiles.backupAndDeleteByRenaming()
+    } else {
+        matchingFiles.deleteRecursively()
     }
 }
 
@@ -209,18 +210,20 @@ fun clearIdePreferences() {
 fun clearIdePreferences(ide: Ide) {
     val preferencesDirectories = locatePreferencesFolderFor(ide)
 
-    when {
-        backup -> preferencesDirectories
+    if (backup) {
+        preferencesDirectories
             .onEach {
                 println("     ℹ️  Clearing preferences for $ide ${extractVersion(it, ide)}...")
             }
             .backupAndDeleteByRenaming()
-        else -> preferencesDirectories
+    } else {
+        preferencesDirectories
             .onEach {
                 println("     ℹ️  Clearing preferences for $ide ${extractVersion(it, ide)}...")
             }
             .deleteRecursively()
     }
+        
 }
 
 fun locatePreferencesFolderFor(ide: Ide): Sequence<File> =
@@ -308,22 +311,24 @@ fun Runtime.nukeGlobalCaches() {
 }
 
 fun printInBold(message: String) {
-    when {
-        isOsWindows() -> println(message)
-        else -> println("\u001B[1;37m$message\u001B[0;37m")
+    if (isOsWindows()) {
+        println(message)
+    } else {
+        println("\u001B[1;37m$message\u001B[0;37m")
     }
 }
 
 fun clearIdeCache(ide: Ide) {
     val cacheDirectories = locateCacheFolderFor(ide)
 
-    when {
-        backup -> cacheDirectories
-            .onEach {
-                println("     ℹ️  Clearing cache for $ide ${extractVersion(it, ide)}...")
-            }
-            .backupAndDeleteByRenaming()
-        else -> cacheDirectories
+    if (backup) {
+        cacheDirectories
+           .onEach {
+               println("     ℹ️  Clearing cache for $ide ${extractVersion(it, ide)}...")
+           }
+           .backupAndDeleteByRenaming()
+    } else {
+        cacheDirectories
             .onEach {
                 println("     ℹ️  Clearing cache for $ide ${extractVersion(it, ide)}...")
             }
@@ -369,9 +374,10 @@ fun File.removeSubfoldersMatching(matcher: (file: File) -> Boolean) {
             it.isDirectory && matcher(it)
         }
 
-    when {
-        backup -> matchingDirectories.backupAndDeleteByRenaming()
-        else -> matchingDirectories.deleteRecursively()
+    if (backup) {
+        matchingDirectories.backupAndDeleteByRenaming()
+    } else { 
+        matchingDirectories.deleteRecursively()
     }
 }
 

--- a/deep-clean.kts
+++ b/deep-clean.kts
@@ -223,7 +223,6 @@ fun clearIdePreferences(ide: Ide) {
             }
             .deleteRecursively()
     }
-        
 }
 
 fun locatePreferencesFolderFor(ide: Ide): Sequence<File> =
@@ -376,7 +375,7 @@ fun File.removeSubfoldersMatching(matcher: (file: File) -> Boolean) {
 
     if (backup) {
         matchingDirectories.backupAndDeleteByRenaming()
-    } else { 
+    } else {
         matchingDirectories.deleteRecursively()
     }
 }


### PR DESCRIPTION
Detekt isn't happy about using when with only 2 options. It violates [`UseIfInsteadOfWhen`](https://github.com/arturbosch/detekt/blob/master/detekt-rules/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhen.kt)

Also, the Kotlin guidelines encourages to use `if-else` when only two options are present:
https://kotlinlang.org/docs/reference/coding-conventions.html#if-versus-when

## Implemented solution

Converted all `when` statements with only two entries to `if-else` statements.

## REQUIRED: pre-PR checklist

* [x] The project compiles/runs
* [x] The implemented solution works as intended
* [x] Dry-run (`-d`) doesn't actually perform any action besides logging
~The `README.md` file has been updated~ N/A 
