### PR TITLE
Clear Maven local repository during nuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Where the options are:
 -n --nuke             ⚠️  THIS IS DANGEROUS SHIT ⚠️  Super-deep clean
                       This includes clearing out global folders, including:
                        * the global Gradle cache
+                       * the global Maven artefacts
                        * the wrapper-downloaded Gradle distros
                        * the Gradle daemon data (logs, locks, etc.)
                        * the Android build cache

--- a/deep-clean.kts
+++ b/deep-clean.kts
@@ -38,6 +38,7 @@ Options:
     -n --nuke             ⚠️  THIS IS DANGEROUS SHIT ⚠️  Super-deep clean
                           This includes clearing out global folders, including:
                            * the global Gradle cache
+                           * the global Maven artefacts
                            * the wrapper-downloaded Gradle distros
                            * the Gradle daemon data (logs, locks, etc.)
                            * the Android build cache

--- a/deep-clean.kts
+++ b/deep-clean.kts
@@ -47,6 +47,7 @@ Options:
 
 val userHome = File(System.getProperty("user.home"))
 val gradleHome = locateGradleHome()
+val mavenLocalRepository = locateMavenLocalRepository()
 
 val workingDir = File(Paths.get("").toAbsolutePath().toString())
 
@@ -137,6 +138,12 @@ fun locateGradleHome(): File? {
         userGradleHome.exists() -> userGradleHome
         else -> null
     }
+}
+
+fun locateMavenLocalRepository(): File? {
+    val mavenHome = File(userHome, ".m2")
+
+    return if (mavenHome.exists()) mavenHome else null
 }
 
 fun CommandLineArguments.isFlagSet(vararg flagAliases: String): Boolean =
@@ -318,6 +325,14 @@ fun Runtime.nukeGlobalCaches() {
     printInBold("🔥 Clearing ${Ide.AndroidStudio} caches...")
     clearIdeCache(Ide.AndroidStudio)
     println()
+
+    printInBold("🔥 Clearing Maven local repository artefacts...")
+    if(mavenLocalRepository != null) {
+        if (verbose) println("     ℹ️  Maven local repository found at: ${mavenLocalRepository.absolutePath}")
+        mavenLocalRepository.removeSubfoldersMatching { it.name.toLowerCase() == "repository" }
+    } else {
+        println("     ⚠️  Unable to locate Maven local repository. Checked ~/.m2")
+    }
 
     printInBold("🔥 Clearing Gradle global cache directories: build-scan-data, caches, daemon, wrapper...")
     if (gradleHome != null) {

--- a/deep-clean.kts
+++ b/deep-clean.kts
@@ -142,9 +142,7 @@ fun locateGradleHome(): File? {
 }
 
 fun locateMavenLocalRepository(): File? {
-    val mavenHome = File(userHome, ".m2")
-
-    return if (mavenHome.exists()) mavenHome else null
+    return File(userHome, ".m2").takeIf { it.exists() }
 }
 
 fun CommandLineArguments.isFlagSet(vararg flagAliases: String): Boolean =
@@ -328,7 +326,7 @@ fun Runtime.nukeGlobalCaches() {
     println()
 
     printInBold("🔥 Clearing Maven local repository artefacts...")
-    if(mavenLocalRepository != null) {
+    if (mavenLocalRepository != null) {
         if (verbose) println("     ℹ️  Maven local repository found at: ${mavenLocalRepository.absolutePath}")
         mavenLocalRepository.removeSubfoldersMatching { it.name.toLowerCase() == "repository" }
     } else {


### PR DESCRIPTION
## What is the aim of this PR?

Recently I have been facing an issue on building a project on my machine. The issue couldn't be reproduced on CI machines or my personal machine. It turned out after a deeper investigation to be a single corrupted artefact in the Maven local  repository which is part of the machine global cache

## Implemented solution

As a part of global cache invalidation, aka nuke, the proposed change locates and clears the global [Maven cache directory](https://www.baeldung.com/maven-local-repository)
```bash
~/.m2        # dir on mac
```

## REQUIRED: pre-PR checklist

* [x] The project compiles/runs
* [x] The implemented solution works as intended
* [x] Dry-run (`-d`) doesn't actually perform any action besides logging
* [x] The `README.md` file has been updated
